### PR TITLE
Fix panic on missing Time key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,11 @@ fn print_version(program: &str, as_json: bool) {
 fn extract_date(obj: &json::JsonValue) -> Result<(DateTime<FixedOffset>, &'static str), &'static str> {
     let possible_keys = ["ts", "time", "timestamp"];
 
-    let prop = possible_keys.iter().find(|x| obj.has_key(x)).unwrap();
+    let prop_key = possible_keys.iter().find(|x| obj.has_key(x));
+    if prop_key.is_none() {
+        return Err("no time field provided");
+    }
+    let prop = prop_key.unwrap();
     let ts = obj[*prop].as_str().unwrap();
     match DateTime::parse_from_rfc3339(ts) {
         Ok(v) => return Ok((v, prop)),
@@ -56,7 +60,7 @@ fn format_line(mut obj: json::JsonValue) -> String {
         Ok(t) => {
             result.push_str(format!("{}", t.0.format("%H:%M:%S2%.3f")).as_str());
             obj.remove(t.1);
-        },
+        }
         Err(_) => result.push_str("00:00:000.000"),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,3 +175,19 @@ fn main() {
         println!("{}", format_line(parsed_line));
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn prints_zeroes_on_missing_timestamp() {
+        let input_str ="{\"message\":\"hi\",\"severity\":\"info\"}";
+        let input_json: json::JsonValue = json::parse(input_str).unwrap();
+        let expected = String::from("00:00:000.000 [INFO ] hi");
+        std::env::set_var("CLICOLOR", "0");
+        let output = format_line(input_json);
+        std::env::remove_var("CLICOLOR");
+        assert_eq!(output, expected);
+    }
+}


### PR DESCRIPTION
If no time key is present the program should just print out `00:00:00.000z` instead of panicking

Closes #4 